### PR TITLE
Some edits to the winapi 0.3 release post

### DIFF
--- a/_posts/2017-12-01-winapi-0.3.md
+++ b/_posts/2017-12-01-winapi-0.3.md
@@ -18,7 +18,7 @@ All of the `-sys` crates on `crates.io` are now deprecated and will have all the
 
 Binding items in `winapi` were previously not organised into modules. This allowed you to use a type, or constant without having to consider where it was defined. If C code or documentation mentioned `HWND`, then it was available as `winapi::HWND`, irrespective of the C header required.
 
-In 0.3, all items are organised into modules based on the Windows SDK header file that defines them. \[[†](#fn†)] `HWND` is now located at `shared::windef::HWND`. To continue the example of `MessageBoxW`, it is defined by `winuser.h`. This means it can now be found in the `um::winuser` module.
+In 0.3, all items are organised into modules based on the Windows SDK header file that defines them. So if you are already familiar with the file structure of the Windows SDK headers, `winapi` now directly mirrors that \[[†](#fn†)]. So in `winapi` 0.3 `HWND` is now located at `shared::windef::HWND`. And to continue the example of `MessageBoxW`, which is defined in `winuser.h`, it's now available in the `um::winuser` module.
 
 You can determine where an item (or the module that corresponds to a particular header) is located by searching the [online `winapi` 0.3 documentation]. Most translated headers will be in the `um` (user-mode) top-level module, items shared between user- and kernel-mode code in the `shared` module, Visual C++-specific items in the `vc` module, and WinRT-related items in the `winrt` module.
 

--- a/_posts/2017-12-01-winapi-0.3.md
+++ b/_posts/2017-12-01-winapi-0.3.md
@@ -38,7 +38,7 @@ There is also an `everything` feature that enables all other feature gates. Enab
 
 ## COM interfaces
 
-All COM interfaces now implement the `Interface` trait, which will allow better `ComPtr` abstractions. Currently this trait exposes a single method which returns the IID of the interface, essential for `QueryInterface` wrappers. For example, to get the IID of the `IUnknown` interface, call `IUnknown::uuidof()`.
+All COM interfaces now implement the `Interface` trait, which will allow better `ComPtr` abstractions. Currently this trait exposes a single method which returns the IID of the interface which is essential for `QueryInterface` wrappers. For example, to get the IID of the `IUnknown` interface, call `IUnknown::uuidof()`.
 
 ## Enumerations
 

--- a/_posts/2017-12-01-winapi-0.3.md
+++ b/_posts/2017-12-01-winapi-0.3.md
@@ -12,6 +12,8 @@ In previous versions of `winapi`, function bindings were separated into their ow
 
 In 0.3, this is no longer true: the `winapi` crate contains all types, constants, macros, *and* functions. As such, dependencies on all `-sys` crates in the winapi family should be removed, and all imports updated to point towards `winapi` itself.
 
+All of the `-sys` crates on `crates.io` are now deprecated and will have all their versions yanked in the near future to prevent future projects from using them. If you still have a project using these, it will continue to work, but if you need to add additional `-sys` crates, you'll need to migrate to `winapi-0.3` instead.
+
 ## Items are now organised into modules.
 
 Binding items in `winapi` were previously not organised into modules. This allowed you to use a type, or constant without having to consider where it was defined. If C code or documentation mentioned `HWND`, then it was available as `winapi::HWND`, irrespective of the C header required.

--- a/_posts/2017-12-01-winapi-0.3.md
+++ b/_posts/2017-12-01-winapi-0.3.md
@@ -4,7 +4,7 @@ title: winapi 0.3
 published: false
 ---
 
-For over a year people have been wondering when the next version of winapi would be published, and today I am happy to announce that winapi 0.3 has finally been published to crates.io! This new version has a lot of changes so let's go over them, as well as any changes you have to make to your own code when migrating to this new version.
+For over a year people have been wondering when the next version of winapi would be published, and today I am happy to announce that winapi 0.3 has finally been [published to crates.io](https://crates.io/crates/winapi)! This new version has a lot of changes so this post will go over them and any changes that will be necessary in your own code when migrating to this new version.
 
 ## COM interfaces
 

--- a/_posts/2017-12-01-winapi-0.3.md
+++ b/_posts/2017-12-01-winapi-0.3.md
@@ -72,9 +72,11 @@ pub const PT_TOUCHPAD: POINTER_INPUT_TYPE = 0x00000005;
 
 However, this `c_void` will not be compatible with `c_void` as used by any other code, unless that code is specifically using `winapi`'s type. This can be fixed by enabling the `std` feature, which causes `winapi::ctypes::c_void` to instead alias to `std::os::raw::c_void`.
 
-## Example
+## Simply Migration Example
 
-Consider the following example program using `winapi` 0.2.
+To make the migration of a project a little more clear, we'll show an example of a simple GUI Hello World example in both `winapi` 0.2 and 0.3.
+
+In `winapi-0.2` it looks like:
 
 ```rust
 //! Add the following to `Cargo.toml`:
@@ -109,7 +111,7 @@ fn main() {
 }
 ```
 
-It would be modified as follows for `winapi` 0.3.
+It would be modified as follows for `winapi-0.3`.
 
 ```rust
 //! Add the following to `Cargo.toml`:

--- a/_posts/2017-12-01-winapi-0.3.md
+++ b/_posts/2017-12-01-winapi-0.3.md
@@ -6,10 +6,6 @@ published: false
 
 For over a year people have been wondering when the next version of winapi would be published, and today I am happy to announce that winapi 0.3 has finally been [published to crates.io](https://crates.io/crates/winapi)! This new version has a lot of changes so this post will go over them and any changes that will be necessary in your own code when migrating to this new version.
 
-## COM interfaces
-
-All COM interfaces now implement the `Interface` trait, which will allow better `ComPtr` abstractions. Currently this trait exposes a single method which returns the IID of the interface, essential for `QueryInterface` wrappers. For example, to get the IID of the `IUnknown` interface, call `IUnknown::uuidof()`.
-
 ## The `-sys` crates are dead. Long live the `winapi` behemoth.
 
 In previous versions of `winapi`, function bindings were separated into their own independent crates based on which import library contained those symbols. For example, the `MessageBoxW` function is exported from `user32.lib`, and was thus bound in the `user32-sys` crate.
@@ -39,6 +35,10 @@ Note that enabling a module *also* enables any modules it depends on for types. 
 Features also control which DLLs will be linked. Enabling `winuser` automatically causes your program to be linked against the `User32` library.
 
 There is also an `everything` feature that enables all other feature gates. Enabling everything will adversely affect build times. \[[‡](#fn‡)]
+
+## COM interfaces
+
+All COM interfaces now implement the `Interface` trait, which will allow better `ComPtr` abstractions. Currently this trait exposes a single method which returns the IID of the interface, essential for `QueryInterface` wrappers. For example, to get the IID of the `IUnknown` interface, call `IUnknown::uuidof()`.
 
 ## Enumerations
 


### PR DESCRIPTION
One thing I also didn't do here but might be a good idea is to add some explanatory text about why the organizational changes (you allude to it being compile times and usability, but don't explicitly state that). You also don't explain *why* the Enumeration changes. You'll likely get questions about many of these changes if you don't explain them or at least point to a PR or issue with background info.